### PR TITLE
add some randomness to wave function collapse worker

### DIFF
--- a/src/pages/wave-function-collapse/collapse.worker.ts
+++ b/src/pages/wave-function-collapse/collapse.worker.ts
@@ -200,9 +200,11 @@ async function start({
 		return false
 	}
 
-	const choices: number[] = []
+	const choices: number[][] = []
 	let solved = false
+	let backtracks = -1
 	do {
+		backtracks++
 		resetBoard()
 		for (let i = 0; i < force.length; i++) {
 			const [x, y] = force[i]
@@ -224,18 +226,20 @@ async function start({
 			} else if (possible.length === 1) {
 				t = possible[0]
 			} else if (choiceIndex === choices.length) {
-				const i = possible.length - 1
-				choices.push(i)
+				const i = Math.floor(Math.random() * possible.length)
+				choices.push(Array.from({ length: possible.length - 1 }, (_, i) => i).filter((_, j) => j !== i))
 				choiceIndex++
 				t = possible[i]
-			} else if (choices.every((c, i) => i < choiceIndex || (i === choiceIndex && c > 0) || (i > choiceIndex && c === 0))) {
-				const i = choices[choiceIndex] - 1
-				choices[choiceIndex] = i
+			} else if (choices.every((c, i) => i < choiceIndex || (i === choiceIndex && c.length > 1) || (i > choiceIndex && c.length <= 1))) {
+				const indices = choices[choiceIndex]
+				const i = indices[Math.floor(Math.random() * indices.length)]
+				choices[choiceIndex] = indices.filter((_, j) => j !== i)
 				choices.length = choiceIndex + 1
 				choiceIndex++
 				t = possible[i]
 			} else {
-				const i = choices[choiceIndex]
+				const indices = choices[choiceIndex]
+				const i = possible.findIndex((t) => !indices.includes(t))
 				t = possible[i]
 				choiceIndex++
 			}
@@ -249,9 +253,9 @@ async function start({
 		} while (lowest !== -1)
 		console.log('loops', loops)
 		solved = isSolved()
-	} while (!solved && choices.some((c) => c > 0))
-
-	console.log('choices', choices.join(' '))
+	} while (!solved && choices.some((c) => c.length > 1))
+	console.log('backtracks', backtracks)
+	// console.log('choices', choices.join(' '))
 	onDone(solved, choices)
 }
 

--- a/src/pages/wave-function-collapse/index.tsx
+++ b/src/pages/wave-function-collapse/index.tsx
@@ -1,8 +1,8 @@
 import styles from './styles.module.css'
 import { Head } from "~/components/Head"
 import type { RouteMeta } from "~/router"
-import type { Incoming, Outgoing } from "./worker"
-import Worker from "./worker?worker"
+import type { Incoming, Outgoing } from "./collapse.worker"
+import Worker from "./collapse.worker?worker"
 import { useEffect, useRef, useState } from "react"
 import * as utils from './utils'
 import * as config from './carcassonne/definition'
@@ -22,11 +22,11 @@ const equivalents = tiles.map((tile) => tiles.filter((other) => other.sides.ever
 
 
 function drawTile(ctx: CanvasRenderingContext2D, w: number, h: number, index: number, rotate: number, x: number, y: number) {
-	if (rotate === 1) x += 1
-	if (rotate === 2) y += 1, x += 1
-	if (rotate === 3) y += 1
+	// if (rotate === 1) x += 1
+	// if (rotate === 2) y += 1, x += 1
+	// if (rotate === 3) y += 1
 	ctx.save()
-	ctx.translate(x * w, y * h)
+	ctx.translate(x * w + w / 2, y * h + h / 2)
 	ctx.rotate(rotate * Math.PI / 2)
 	const setY = (index / config.params.grid.width) | 0
 	const setX = index % config.params.grid.width
@@ -36,8 +36,8 @@ function drawTile(ctx: CanvasRenderingContext2D, w: number, h: number, index: nu
 		setY * config.params.tile.height,
 		config.params.tile.width,
 		config.params.tile.height,
-		0,
-		0,
+		-w / 2,
+		-h / 2,
 		w,
 		h
 	)


### PR DESCRIPTION
Adding randomness to wave function collapse makes the result prettier.

However it makes it harder to keep track of the choices made (choices become random instead of in-order), and this current implementation now creates a lot of small arrays.

We probably can make a more efficient implementation by keeping a single `choices` array of length `width * height * tiles` (since for each of the `w`×`h` cells, we can have up to `t` options)